### PR TITLE
Use a lighter tone for the completed label summary text.

### DIFF
--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -38,7 +38,7 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         label.wrap = true;
         label.xalign = 0;
 
-        if (component.get_status () == ICal.PropertyStatus.COMPLETED) {
+        if (completed) {
             label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
         }
 

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -39,7 +39,7 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         summary_label.xalign = 0;
 
         if (completed) {
-            label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+            summary_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
         }
 
         var grid = new Gtk.Grid ();

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -38,6 +38,10 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         label.wrap = true;
         label.xalign = 0;
 
+        if (component.get_status () == ICal.PropertyStatus.COMPLETED) {
+            label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+        }
+
         var grid = new Gtk.Grid ();
         grid.margin = 3;
         grid.margin_start = grid.margin_end = 24;


### PR DESCRIPTION
To make them easier to distinguish from the ones which are incomplete in a list where items of both states are shown.