### PR TITLE
Output due date where it is set

### DIFF
--- a/data/TaskRow.css
+++ b/data/TaskRow.css
@@ -1,0 +1,24 @@
+/*
+* Copyright 2019 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+*/
+
+.due-date {
+    border-radius: 12px;
+    background: lightgray;
+}

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -70,7 +70,7 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
                 due.second
             );
 
-            var due_label = new Gtk.Label (due_datetime.format ("%x %X"));
+            var due_label = new Gtk.Label (Granite.DateTime.get_relative_datetime (due_datetime));
             due_label.wrap = true;
             due_label.xalign = 0;
             due_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -49,6 +49,36 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         grid.add (check);
         grid.add (summary_label);
 
+        Gtk.Widget grid_attach_next_to_ref = summary_label;
+
+        var due = component.get_due ();
+        if (!due.is_null_time ()) {
+            GLib.TimeZone due_timezone = null;
+            if (due.get_tzid () != null) {
+                due_timezone = new GLib.TimeZone (due.get_tzid ());
+            } else {
+                due_timezone = new GLib.TimeZone.local();
+            }
+
+            var due_datetime = new GLib.DateTime (
+                due_timezone,
+                due.year,
+                due.month,
+                due.day,
+                due.hour,
+                due.minute,
+                due.second
+            );
+
+            var due_label = new Gtk.Label (due_datetime.format ("%x %X"));
+            due_label.wrap = true;
+            due_label.xalign = 0;
+            due_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
+            grid.attach_next_to (due_label, grid_attach_next_to_ref, Gtk.PositionType.BOTTOM);
+            grid_attach_next_to_ref = due_label;
+        }
+
         var description = component.get_description ();
         if (description != null) {
             description = description.replace ("\r", "").strip ();
@@ -69,7 +99,8 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
                 description_label.ellipsize = Pango.EllipsizeMode.END;
                 description_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-                grid.attach_next_to (description_label, summary_label, Gtk.PositionType.BOTTOM);
+                grid.attach_next_to (description_label, grid_attach_next_to_ref, Gtk.PositionType.BOTTOM);
+                grid_attach_next_to_ref = description_label;
             }
         }
 

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -34,16 +34,40 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         check.active = completed;
         check.sensitive = false;
 
-        var label = new Gtk.Label (component.get_summary ());
-        label.wrap = true;
-        label.xalign = 0;
+        var summary_label = new Gtk.Label (component.get_summary ());
+        summary_label.wrap = true;
+        summary_label.xalign = 0;
 
         var grid = new Gtk.Grid ();
         grid.margin = 3;
         grid.margin_start = grid.margin_end = 24;
         grid.column_spacing = 6;
         grid.add (check);
-        grid.add (label);
+        grid.add (summary_label);
+
+        var description = component.get_description ();
+        if (description != null) {
+            description = description.replace ("\r", "").strip ();
+            string[] lines = description.split ("\n");
+            string stripped_description = lines[0].strip ();
+            for (int i = 1; i < lines.length; i++) {
+                string stripped_line = lines[i].strip ();
+
+                if (stripped_line.length > 0 ) {
+                    stripped_description += " " + lines[i].strip ();
+                }
+            }
+
+            if (stripped_description.length > 0) {
+                var description_label = new Gtk.Label (stripped_description);
+                description_label.xalign = 0;
+                description_label.lines = 1;
+                description_label.ellipsize = Pango.EllipsizeMode.END;
+                description_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
+                grid.attach_next_to (description_label, summary_label, Gtk.PositionType.BOTTOM);
+            }
+        }
 
         add (grid);
     }

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -38,6 +38,10 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         summary_label.wrap = true;
         summary_label.xalign = 0;
 
+        if (completed) {
+            summary_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+        }
+
         var grid = new Gtk.Grid ();
         grid.margin = 3;
         grid.margin_start = grid.margin_end = 24;


### PR DESCRIPTION
This fixes #49.

Open task:
- [x] Is there a way we can output the time in the users preferred locale, but without seconds? I think the seconds output is confusing and don't see any added value in it:

![Screenshot from 2019-10-20 11 07 36@2x](https://user-images.githubusercontent.com/392542/67157250-e56f5c00-f329-11e9-9569-3d928bf740e1.png)
