### PR TITLE
TaskSettingsPopover: Add a frame and margins around description

### DIFF
--- a/src/Widgets/TaskSettingsPopover.vala
+++ b/src/Widgets/TaskSettingsPopover.vala
@@ -118,23 +118,23 @@ public class Tasks.TaskSettingsPopover : Gtk.Popover {
         description_scrolled_window.height_request = 140;
         description_scrolled_window.add (description_textview);
 
+        var description_frame = new Gtk.Frame (null);
+        description_frame.margin = 12;
+        description_frame.margin_bottom = 0;
+        description_frame.add (description_scrolled_window);
+
         var done_button = new Gtk.Button ();
         done_button.label = _("Done");
         done_button.halign = Gtk.Align.END;
-        done_button.margin_right = 6;
-        done_button.margin_top = 6;
-        done_button.margin_bottom = 3;
+        done_button.margin = 12;
 
         var grid = new Gtk.Grid ();
         grid.orientation = Gtk.Orientation.VERTICAL;
-        grid.margin_top = grid.margin_bottom = 3;
+        grid.margin_top = 3;
         grid.add (summary_entry);
-        grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
         grid.add (due_button);
         grid.add (due_datetimepicker);
-        grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-        grid.add (description_scrolled_window);
-        grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+        grid.add (description_frame);
         grid.add (done_button);
         grid.show_all ();
 


### PR DESCRIPTION
Fixes a visual issue with the popover arrow:

## BEFORE
![Screenshot from 2019-12-18 09 04 10@2x](https://user-images.githubusercontent.com/7277719/71107208-808f8100-2175-11ea-8a8a-1dc0d26854d3.png)

## AFTER
![Screenshot from 2019-12-18 09 02 42@2x](https://user-images.githubusercontent.com/7277719/71107071-4cb45b80-2175-11ea-86c3-0e6eedeab448.png)
