### PR TITLE
TaskRow: Don't use editable label

### DIFF
--- a/data/TaskRow.css
+++ b/data/TaskRow.css
@@ -52,3 +52,7 @@ row entry.flat  {
     border: none;
     padding: 0;
 }
+
+row entry.flat:focus {
+    opacity: 1;
+}

--- a/data/TaskRow.css
+++ b/data/TaskRow.css
@@ -46,3 +46,9 @@ row.card {
     margin-top: 1px;
     padding-top: 6px;
 }
+
+row entry.flat  {
+    background: transparent;
+    border: none;
+    padding: 0;
+}


### PR DESCRIPTION
Instead of using EditableLabel, we use a flat entry.

This makes it so when we're editing that label we're editing the task. Also make sure keyboard events match up.

Manually listening to entry activation should eventually be replaced with `activates_default`, but we can't do that while buttons are in another class so it'll have to wait