### PR TITLE
Fix for calcomponent-created in libecal 1

### DIFF
--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -468,7 +468,7 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
 #else
         ICal.Time created;
         comp.get_created (out created);
-        return created.is_valid_time () != 0;
+        return !created.is_null_time ();
 #endif
     }
 }


### PR DESCRIPTION
For whatever reason after compiling the new master branch PR #116 no longer worked. This PR fixes the problem.