### PR TITLE
Restore Header Coloring

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -82,7 +82,8 @@ public class Tasks.Application : Gtk.Application {
         if (!providers.has_key (color)) {
             string style = """
                 @define-color colorAccent %s;
-            """.printf (color);
+                @define-color accent_color %s;
+            """.printf (color, color);
 
             try {
                 var style_provider = new Gtk.CssProvider ();


### PR DESCRIPTION
This makes each source's color be used again in the big header of the main view.