### PR TITLE
TaskRow: Save style context and use Rounded

### DIFF
--- a/data/TaskRow.css
+++ b/data/TaskRow.css
@@ -28,7 +28,6 @@
 }
 
 row {
-    border-radius: 3px;
     transition: all 250ms ease-in-out;
 }
 

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -47,6 +47,7 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
     private Gtk.Revealer task_form_revealer;
     private Gtk.Switch due_switch;
     private Gtk.TextBuffer description_textbuffer;
+    private unowned Gtk.StyleContext style_context;
 
     private static Gtk.CssProvider taskrow_provider;
 
@@ -196,7 +197,10 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
 
         add (revealer);
         margin_start = margin_end = 12;
-        get_style_context ().add_provider (taskrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        style_context = get_style_context ();
+        style_context.add_class (Granite.STYLE_CLASS_ROUNDED);
+        style_context.add_provider (taskrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         if (created) {
             check.show ();
@@ -313,8 +317,6 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
     public void reveal_child_request (bool value) {
         task_form_revealer.reveal_child = value;
         task_details_reveal_request (!value);
-
-        unowned Gtk.StyleContext style_context = get_style_context ();
 
         if (value) {
             style_context.add_class ("collapsed");


### PR DESCRIPTION
Save the style context so we don't get it every time we hide/show task details

Use Granite rounded style class instead of hard coding card radius