### PR TITLE
TaskRow: Add TRANSLATORS comment for due date and time

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,8 @@
 i18n.gettext(meson.project_name (),
-    args: '--directory=' + meson.source_root(),
+    args: [
+        '--directory=' + meson.source_root(),
+        '-cTRANSLATORS'
+    ],
     preset: 'glib'
 )
 

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -401,8 +401,8 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
                     due_label.label = _("%s").printf (
                         due_date_time.format (Granite.DateTime.get_default_time_format (format.contains ("12h")))
                     );
-
                 } else {
+                    ///TRANSLATORS: Represents due date and time of a task, e.g. "Tomorrow at 9:00 AM"
                     due_label.label = _("%s at %s").printf (
                         Tasks.Util.get_relative_date (due_date_time),
                         due_date_time.format (Granite.DateTime.get_default_time_format (format.contains ("12h")))


### PR DESCRIPTION
It would be difficult to understand the context of the string "%s at %s" without any comment for translators.
