### PR TITLE
Code style and CSS fixes

### DIFF
--- a/data/EntryPopover.css
+++ b/data/EntryPopover.css
@@ -1,5 +1,5 @@
 /*
-* Copyright 2019 elementary, Inc. (https://elementary.io)
+* Copyright 2020 elementary, Inc. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -18,32 +18,23 @@
 *
 */
 
-row {
-    transition: all 250ms ease-in-out;
+entry-popover grid {
+    border-radius: 3px;
+    background: @SILVER_300;
 }
 
-row:focus:not(.card) {
-    background-color: shade (@base_color, 0.8);
+entry-popover button image,
+entry-popover button label {
+    color: @SILVER_900;
+    font-size: 0.9em;
+    font-weight: 600;
 }
 
-row.card {
-    background-color: @base_color;
-    margin-bottom: 12px;
-    margin-top: 1px;
-    padding-top: 6px;
+entry-popover.error grid {
+    background: alpha (@error_color, 0.2);
 }
 
-row entry.flat  {
-    background: transparent;
-    border-style: solid;
-    border-color: transparent;
-    padding: 0;
-}
-
-row entry.flat:focus {
-    opacity: 1;
-}
-
-row:not(.card) entry.add-task {
-    border-color: alpha (@text_color, 0.25);
+entry-popover.error button image,
+entry-popover.error button label {
+    color: @error_color;
 }

--- a/data/gresource.xml
+++ b/data/gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/io/elementary/tasks">
     <file compressed="true">EditableLabel.css</file>
+    <file compressed="true">EntryPopover.css</file>
     <file compressed="true">HeaderBar.css</file>
     <file compressed="true">SourceRow.css</file>
     <file compressed="true">TaskRow.css</file>

--- a/src/Widgets/DateTimePopover.vala
+++ b/src/Widgets/DateTimePopover.vala
@@ -18,29 +18,30 @@
 */
 
 public class Tasks.DateTimePopover : Tasks.EntryPopover<GLib.DateTime?> {
-
-    private Gtk.Calendar calendar = new Gtk.Calendar () {
-        sensitive = false
-    };
-
-    private Granite.Widgets.TimePicker timepicker = new Granite.Widgets.TimePicker () {
-        sensitive = false
-    };
-
-    private Gtk.Button today_button = new Gtk.Button () {
-        label = _("Today")
-    };
-
-    private Gtk.Grid grid = new Gtk.Grid () {
-        margin = 6,
-        row_spacing = 3,
-        column_spacing = 6
-    };
+    private Gtk.Calendar calendar;
+    private Granite.Widgets.TimePicker timepicker;
 
     construct {
+        calendar = new Gtk.Calendar () {
+            sensitive = false
+        };
+
+        var today_button = new Gtk.Button () {
+            label = _("Today")
+        };
+
+        timepicker = new Granite.Widgets.TimePicker () {
+            sensitive = false
+        };
+
+        var grid = new Gtk.Grid () {
+            margin = 6,
+            row_spacing = 3,
+            column_spacing = 6
+        };
         grid.attach (calendar, 0, 0, 2);
-        grid.attach (today_button, 0, 1, 1);
-        grid.attach (timepicker, 1, 1, 1);
+        grid.attach (today_button, 0, 1);
+        grid.attach (timepicker, 1, 1);
         grid.show_all ();
 
         popover.add (grid);

--- a/src/Widgets/DateTimePopover.vala
+++ b/src/Widgets/DateTimePopover.vala
@@ -25,6 +25,7 @@ public class Tasks.DateTimePopover : Tasks.EntryPopover<GLib.DateTime?> {
         calendar = new Gtk.Calendar () {
             sensitive = false
         };
+        calendar.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
 
         var today_button = new Gtk.Button () {
             label = _("Today")

--- a/src/Widgets/EntryPopover.vala
+++ b/src/Widgets/EntryPopover.vala
@@ -27,10 +27,16 @@ public abstract class Tasks.EntryPopover<T> : Gtk.EventBox {
     public signal void value_changed (T value);
     public signal string? value_format (T value);
 
+    private static Gtk.CssProvider style_provider;
     private Gtk.MenuButton popover_button;
 
     class construct {
         set_css_name ("entry-popover");
+    }
+
+    static construct {
+        style_provider = new Gtk.CssProvider ();
+        style_provider.load_from_resource ("io/elementary/tasks/EntryPopover.css");
     }
 
     construct {
@@ -44,10 +50,12 @@ public abstract class Tasks.EntryPopover<T> : Gtk.EventBox {
             label = (placeholder != null && placeholder.length > 0 ? placeholder : _("Set Value")),
             popover = popover
         };
+        popover_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var delete_button = new Gtk.Button.from_icon_name ("window-close", Gtk.IconSize.BUTTON) {
+        var delete_button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.BUTTON) {
             tooltip_text = _("Remove")
         };
+        delete_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var delete_button_revealer = new Gtk.Revealer () {
             transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT,
@@ -55,12 +63,10 @@ public abstract class Tasks.EntryPopover<T> : Gtk.EventBox {
         };
         delete_button_revealer.add (delete_button);
 
-        var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
-            baseline_position = Gtk.BaselinePosition.CENTER,
-            homogeneous = false
-        };
+        var button_box = new Gtk.Grid ();
         button_box.add (popover_button);
         button_box.add (delete_button_revealer);
+        button_box.get_style_context ().add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         add (button_box);
 

--- a/src/Widgets/EntryPopover.vala
+++ b/src/Widgets/EntryPopover.vala
@@ -18,60 +18,54 @@
 */
 
 public abstract class Tasks.EntryPopover<T> : Gtk.EventBox {
-
+    public Gtk.ArrowType direction { get; set; }
+    public Gtk.Image image { get; set; }
+    public Gtk.Popover popover { get; private set; }
     public string? placeholder { get; set; }
-
-    public Gtk.Image image {
-        get { return (Gtk.Image) popover_button.image; }
-        set { popover_button.image = value; }
-    }
-
-    public Gtk.Popover popover {
-        get { return popover_button.popover; }
-    }
-
-    public Gtk.ArrowType direction {
-        get { return popover_button.direction; }
-        set { popover_button.direction = value; }
-    }
 
     public T value { get; set; }
     public signal void value_changed (T value);
     public signal string? value_format (T value);
 
-    private Gtk.Box button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
-        baseline_position = Gtk.BaselinePosition.CENTER,
-        homogeneous = false
-    };
+    private Gtk.MenuButton popover_button;
 
-    private Gtk.MenuButton popover_button = new Gtk.MenuButton () {
-        always_show_image = true,
-        use_popover = true
-    };
-
-    private Gtk.Button delete_button = new Gtk.Button.from_icon_name ("window-close", Gtk.IconSize.BUTTON) {
-        always_show_image = true,
-        tooltip_text = _("Remove")
-    };
-
-    private Gtk.Revealer delete_button_revealer = new Gtk.Revealer () {
-        transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT,
-        reveal_child = false
-    };
+    class construct {
+        set_css_name ("entry-popover");
+    }
 
     construct {
-        set_css_name ("entry-popover");
-
         events |= Gdk.EventMask.ENTER_NOTIFY_MASK
             | Gdk.EventMask.LEAVE_NOTIFY_MASK;
 
-        popover_button.label = (placeholder != null && placeholder.length > 0 ? placeholder : _("Set Value"));
-        popover_button.popover = new Gtk.Popover (popover_button);
+        popover = new Gtk.Popover (popover_button);
 
+        popover_button = new Gtk.MenuButton () {
+            always_show_image = true,
+            label = (placeholder != null && placeholder.length > 0 ? placeholder : _("Set Value")),
+            popover = popover
+        };
+
+        var delete_button = new Gtk.Button.from_icon_name ("window-close", Gtk.IconSize.BUTTON) {
+            tooltip_text = _("Remove")
+        };
+
+        var delete_button_revealer = new Gtk.Revealer () {
+            transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT,
+            reveal_child = false
+        };
         delete_button_revealer.add (delete_button);
+
+        var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
+            baseline_position = Gtk.BaselinePosition.CENTER,
+            homogeneous = false
+        };
         button_box.add (popover_button);
         button_box.add (delete_button_revealer);
+
         add (button_box);
+
+        bind_property ("image", popover_button, "image");
+        bind_property ("direction", popover_button, "direction");
 
         delete_button.clicked.connect (() => {
             value = null;

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -96,9 +96,6 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         summary_entry_context.add_class (Gtk.STYLE_CLASS_FLAT);
         summary_entry_context.add_provider (taskrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        unowned Gtk.StyleContext due_datetime_popover_context = due_datetime_popover.get_style_context ();
-        due_datetime_popover_context.add_provider (taskrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
         due_datetime_popover_revealer.add (due_datetime_popover);
 
         due_datetime_popover.value_format.connect ((value) => {
@@ -272,8 +269,6 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
             update_request ();
         });
         update_request ();
-
-        task_form_revealer.bind_property ("reveal_child", due_datetime_popover, "sensitive", GLib.BindingFlags.SYNC_CREATE);
     }
 
     private void reset_create () {

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -31,16 +31,8 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
 
     private bool created;
 
-    private Tasks.DateTimePopover due_datetime_popover = new Tasks.DateTimePopover () {
-        placeholder = _("Set Due"),
-        image = new Gtk.Image.from_icon_name ("office-calendar-symbolic", Gtk.IconSize.BUTTON)
-    };
-
-    private Gtk.Revealer due_datetime_popover_revealer = new Gtk.Revealer () {
-        transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT,
-        margin_end = 6,
-        reveal_child = false
-    };
+    private Tasks.DateTimePopover due_datetime_popover;
+    private Gtk.Revealer due_datetime_popover_revealer;
 
     private Gtk.Stack state_stack;
     private Gtk.Image icon;
@@ -96,6 +88,16 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         summary_entry_context.add_class (Gtk.STYLE_CLASS_FLAT);
         summary_entry_context.add_provider (taskrow_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
+        due_datetime_popover = new Tasks.DateTimePopover () {
+            image = new Gtk.Image.from_icon_name ("office-calendar-symbolic", Gtk.IconSize.BUTTON),
+            placeholder = _("Set Due")
+        };
+
+        due_datetime_popover_revealer = new Gtk.Revealer () {
+            margin_end = 6,
+            reveal_child = false,
+            transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT
+        };
         due_datetime_popover_revealer.add (due_datetime_popover);
 
         due_datetime_popover.value_format.connect ((value) => {


### PR DESCRIPTION
Widget construction should happen in the construct block. We don't use this style of constructing widgets during property declaration anywhere else. As you can see here, doing it that way lead to a lot of things being scoped to the whole class that are only accessed during construct.

We can also use property bindings to make our property setters simpler and can do a one line getter with `{ get; private set; }`

There were a number of extra properties here. `always_show_image` only needs to be set if the button also contains text. `use_popover` only applies if you're construction a menu button from a model.

You should use `-symbolic` icon names for flat styled icons so that they pick up the text color. This is especially important for dark mode.

Speaking of text color, there appears to be a bug in Greenfield that's making the error text color not work as expected, so I have to investigate that