### PR TITLE
TaskRow: Prevent the use of NULL ICal.Time object

### DIFF
--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -453,7 +453,12 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
         if (comp == null) {
             return false;
         }
-        var created = comp.get_created ();
+
+        ICal.Time? created = comp.get_created ();
+        if (created == null) {
+            return false;
+        }
+
         return created.is_valid_time ();
     }
 }


### PR DESCRIPTION
The ICal.Component might exist but not the created time.