### PR TITLE
Sort Task Lists using calendar-order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 build/*
+.flatpak-builder/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,33 @@
 
 ## Building and Installation
 
+### Build with Flatpak
+
+_Starting with elementary 6 Odin, Flatpak is the preferred build method._
+
+You'll need to install the following dependencies:
+
+```bash
+flatpak --user install flathub \
+  org.gnome.Sdk//3.38 \
+  io.elementary.BaseApp//juno-20.08
+```
+
+Run `flatpak-builder` to build:
+
+```bash
+flatpak-builder --force-clean build io.elementary.tasks.yml
+```
+
+To install, use `flatpak-builder --install`, then execute with `io.elementary.tasks`:
+
+```bash
+flatpak-builder --install --user --force-clean build io.elementary.tasks.yml
+io.elementary.tasks
+```
+
+### Build with Meson
+
 You'll need the following dependencies:
 * glib-2.0
 * gobject-2.0


### PR DESCRIPTION
This PR will eventually fix #169 by adding support for the `calendar-order` property. Because this property was added in a newer Evolution Data Server version than shipped with the Ubuntu 20.04 LTS base, using Flatpak is a must.

This way, we can package a newer version of the needed `evolution-data-server` and ship it within the Tasks app.