### PR TITLE
Use row_activated instead of focus to allow future drag and drop

### DIFF
--- a/src/ListView.vala
+++ b/src/ListView.vala
@@ -64,7 +64,6 @@ public class Tasks.ListView : Gtk.Grid {
 
     private Gtk.ListBox add_task_list;
     private Gtk.ListBox task_list;
-    private Tasks.TaskRow active_task_row;
 
     construct {
         views = new Gee.ArrayList<ECal.ClientView> ((Gee.EqualDataFunc<ECal.ClientView>?) direct_equal);
@@ -118,13 +117,15 @@ public class Tasks.ListView : Gtk.Grid {
         placeholder_context.add_class (Granite.STYLE_CLASS_H2_LABEL);
 
         add_task_list = new Gtk.ListBox () {
-            selection_mode = Gtk.SelectionMode.NONE,
-            margin_top = 24
+            margin_top = 24,
+            selection_mode = Gtk.SelectionMode.SINGLE,
+            activate_on_single_click = true
         };
         add_task_list.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
 
         task_list = new Gtk.ListBox () {
-            selection_mode = Gtk.SelectionMode.NONE
+            selection_mode = Gtk.SelectionMode.MULTIPLE,
+            activate_on_single_click = true
         };
         task_list.set_filter_func (filter_function);
         task_list.set_placeholder (placeholder);
@@ -155,24 +156,12 @@ public class Tasks.ListView : Gtk.Grid {
 
         add_task_list.row_activated.connect ((row) => {
             var task_row = (Tasks.TaskRow) row;
-
-            if (active_task_row != null) {
-                active_task_row.reveal_child_request (false);
-            }
-
             task_row.reveal_child_request (true);
-            active_task_row = task_row;
         });
 
         task_list.row_activated.connect ((row) => {
             var task_row = (Tasks.TaskRow) row;
-
-            if (active_task_row != null) {
-                active_task_row.reveal_child_request (false);
-            }
-
             task_row.reveal_child_request (true);
-            active_task_row = task_row;
         });
 
         notify["source"].connect (() => {
@@ -208,6 +197,9 @@ public class Tasks.ListView : Gtk.Grid {
                             return GLib.Source.REMOVE;
                         });
                     });
+                });
+                add_task_row.unselect.connect (() => {
+                    add_task_list.unselect_row (add_task_row);
                 });
                 add_task_list.add (add_task_row);
             }
@@ -398,6 +390,10 @@ public class Tasks.ListView : Gtk.Grid {
                         return GLib.Source.REMOVE;
                     });
                 });
+            });
+
+            task_row.unselect.connect (() => {
+                task_list.unselect_row (task_row);
             });
 
             task_list.add (task_row);

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -23,6 +23,7 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
     public signal void task_completed (ECal.Component task);
     public signal void task_changed (ECal.Component task);
     public signal void task_removed (ECal.Component task);
+    public signal void unselect ();
 
     public bool completed { get; private set; }
     public E.Source source { get; construct; }
@@ -357,9 +358,9 @@ public class Tasks.TaskRow : Gtk.ListBoxRow {
 
     private void cancel_edit () {
         if (created) {
-            move_focus (Gtk.DirectionType.TAB_BACKWARD);
+            unselect ();
         } else {
-            move_focus (Gtk.DirectionType.TAB_FORWARD);
+            unselect ();
             reset_create ();
         }
         var icalcomponent = task.get_icalcomponent ();


### PR DESCRIPTION
This PR lays the foundation to implement drag & drop of tasks (#168). That means, we avoid `grab_focus` and rely on list selection functionality provided by ListBox to expand/collapse a TaskRow.