### PR TITLE
flatpak manifest: Add DRI permission

### DIFF
--- a/io.elementary.tasks.yml
+++ b/io.elementary.tasks.yml
@@ -4,6 +4,7 @@ runtime-version: '6'
 sdk: io.elementary.Sdk
 command: io.elementary.tasks
 finish-args:
+  - '--device=dri'
   - '--share=ipc'
   - '--share=network'
   - '--socket=fallback-x11'


### PR DESCRIPTION
Fixes #262 

I don't know which library we're using here that is trying to initialize an OpenGL context when it starts up (champlain maybe), but it's causing the application to crash on start with devices using the proprietary nvidia driver.

We should add this permission in by default.