### PR TITLE
Gitignore: .flatpak-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 build/*
+.flatpak-builder


### PR DESCRIPTION
If not ignored, VSCodium's Git functionality crashes during building the Flatpak due to too many files beeing watched.