### PR TITLE
Fix account header in sidebar

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -344,6 +344,7 @@ public class Tasks.MainWindow : Hdy.ApplicationWindow {
         if (lbbefore != null && lbbefore is Tasks.Widgets.SourceRow) {
             var before = (Tasks.Widgets.SourceRow) lbbefore;
             if (row.source.parent == before.source.parent) {
+                row.set_header (null);
                 return;
             }
         }


### PR DESCRIPTION
There was an issue where the same account name was displayed multiple times in the sidebar after a new task list was added. This only happens if the headers in the sidebar were already displayed and the user adds a new list with a name which occurs newly as the first item in the list. In this case we need to make sure we remove any previously added header label - and that's exactly what this PR does:

**Without the fix:**

https://user-images.githubusercontent.com/392542/131247492-8509ecac-f7dc-4831-add9-7f5b984e7119.mp4


**With the fix:**

https://user-images.githubusercontent.com/392542/131247495-f719c353-1d2c-46d7-8843-d7fecdd720a6.mp4
