### PR TITLE
Fix cursor placing on focus

### DIFF
--- a/data/tasks.appdata.xml.in
+++ b/data/tasks.appdata.xml.in
@@ -22,6 +22,7 @@
           <li>Fix an issue where an account name header could be displayed multiple times in the sidebar</li>
           <li>Fix an issue with long descriptions being truncated at the beginning instead of the end</li>
           <li>Fix an issue where removing descriptions wasn't saved</li>
+          <li>Fix an issue with placing the cursor in descriptions</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -322,14 +322,6 @@ public class Tasks.Widgets.TaskRow : Gtk.ListBoxRow {
             activate ();
         });
 
-        description_textview.button_press_event.connect ((sender, event) => {
-            if (event.type == Gdk.EventType.BUTTON_PRESS && !description_textview.has_focus) {
-                description_textview.grab_focus ();
-                return Gdk.EVENT_STOP;
-            }
-            return Gdk.EVENT_PROPAGATE;
-        });
-
         cancel_button.clicked.connect (() => {
             cancel_edit ();
         });


### PR DESCRIPTION
During my HyperTextView testings I noticed the cursor placing in the description text view does not behave as expected on focus. This PR fixes this.

**Without this PR**

https://user-images.githubusercontent.com/392542/132178799-8fba8b44-2a44-4cc9-83ac-f36bcaafb309.mp4

**With this PR**

https://user-images.githubusercontent.com/392542/132178429-2496e6bc-d0a6-4133-b126-96c9e6c39691.mp4

