### PR TITLE
Load only non-completed tasks by default

### DIFF
--- a/data/tasks.appdata.xml.in
+++ b/data/tasks.appdata.xml.in
@@ -22,6 +22,7 @@
           <li>Fix an issue where an account name header could be displayed multiple times in the sidebar</li>
           <li>Fix an issue with long descriptions being truncated at the beginning instead of the end</li>
           <li>Fix an issue where removing descriptions wasn't saved</li>
+          <li>Improve performance in lists with lots of completed tasks</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/Widgets/TaskListGrid.vala
+++ b/src/Widgets/TaskListGrid.vala
@@ -199,7 +199,7 @@ public class Tasks.Widgets.TaskListGrid : Gtk.Grid {
         if (show_completed) {
             set_view_for_query ("(contains? 'any' '')");
         } else {
-            set_view_for_query ("AND (NOT is-completed?) (contains? 'any' '')");
+            set_view_for_query ("NOT is-completed?");
         }
     }
 

--- a/src/Widgets/TaskListGrid.vala
+++ b/src/Widgets/TaskListGrid.vala
@@ -20,7 +20,7 @@
 
 public class Tasks.Widgets.TaskListGrid : Gtk.Grid {
     public E.Source source { get; construct; }
-    private ECal.ClientView view;
+    private ECal.ClientView? view = null;
 
     private EditableLabel editable_title;
     private Gtk.ListBox add_task_list;
@@ -32,16 +32,7 @@ public class Tasks.Widgets.TaskListGrid : Gtk.Grid {
     }
 
     construct {
-        try {
-            view = Tasks.Application.model.create_task_list_view (
-                source,
-                "(contains? 'any' '')",
-                on_tasks_added,
-                on_tasks_modified,
-                on_tasks_removed );
-        } catch (Error e) {
-            critical ("Error creating view for source %s: %s", source.display_name, e.message);
-        }
+        set_view_for_query ("AND (NOT is-completed?) (contains? 'any' '')");
 
         E.SourceRegistry? registry = null;
         try {
@@ -199,6 +190,23 @@ public class Tasks.Widgets.TaskListGrid : Gtk.Grid {
         });
 
         show_all ();
+    }
+
+    private void set_view_for_query (string query) {
+        if (view != null) {
+            Application.model.destroy_task_list_view (view);
+        }
+
+        try {
+            view = Tasks.Application.model.create_task_list_view (
+                source,
+                query,
+                on_tasks_added,
+                on_tasks_modified,
+                on_tasks_removed );
+        } catch (Error e) {
+            critical ("Error creating view with query for source %s[%s]: %s", source.display_name, query, e.message);
+        }
     }
 
     private void on_row_activated (Gtk.ListBoxRow row) {

--- a/src/Widgets/TaskListGrid.vala
+++ b/src/Widgets/TaskListGrid.vala
@@ -191,11 +191,6 @@ public class Tasks.Widgets.TaskListGrid : Gtk.Grid {
     }
 
     private void on_show_completed_changed (bool show_completed) {
-        var children = task_list.get_children ();
-        foreach (unowned var child in children) {
-            task_list.remove (child);
-        }
-
         if (show_completed) {
             set_view_for_query ("(contains? 'any' '')");
         } else {
@@ -204,6 +199,11 @@ public class Tasks.Widgets.TaskListGrid : Gtk.Grid {
     }
 
     private void set_view_for_query (string query) {
+        var children = task_list.get_children ();
+        foreach (unowned var child in children) {
+            task_list.remove (child);
+        }
+
         if (view != null) {
             Application.model.destroy_task_list_view (view);
         }


### PR DESCRIPTION
Fixes a crash experienced by users with a lot of tasks per list (https://github.com/elementary/tasks/issues/294). The root cause there is, that we are loading all tasks per default - even the completed ones.

This PR mitigates the situation by only loading the non-completed tasks by default. If the user enables "Show Completed", then a new query is executed which also retrieves the completed tasks.

Please note, loading the completed tasks as well would still lead to the crash. But in Gtk3 there is no builtin way to mitigate this, because Gtk.ListBox simply renders whatever we throw at it - instead of only doing so for the visible area only. A more elegant fix would be to use [Gtk4's ListView](https://valadoc.org/gtk4/Gtk.ListView.html) - but at the time of writing this is not possible, since [we can't pack Tasks as Flatpak](https://github.com/elementary/switchboard-plug-onlineaccounts/issues/209) right now.

Therefore this strategy at least [solves the immediate problem](https://github.com/elementary/tasks/issues/294#issuecomment-918549321) and we can refactor this later on.