### PR TITLE
Refactor: Use Gtk.Application.active_window

### DIFF
--- a/data/tasks.appdata.xml.in
+++ b/data/tasks.appdata.xml.in
@@ -13,6 +13,14 @@
     </p>
   </description>
   <releases>
+    <release version="6.2.0" date="2022-01-19" urgency="medium">
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>Send a notification when a task is due</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.1.0" date="2021-12-13" urgency="medium">
       <description>
         <p>Features:</p>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -75,7 +75,7 @@ public class Tasks.Application : Gtk.Application {
             model.start.begin ();
 
             var main_window = new MainWindow (this);
-            add_window(main_window);
+            add_window (main_window);
 
             int window_x, window_y;
             var rect = Gtk.Allocation ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -27,7 +27,6 @@ public class Tasks.Application : Gtk.Application {
     public static GLib.Settings settings;
     public static Tasks.TaskModel model;
     public static bool run_in_background = false;
-    private MainWindow? main_window = null;
 
     public const Gtk.TargetEntry[] DRAG_AND_DROP_TASK_DATA = {
         { "text/uri-list", Gtk.TargetFlags.SAME_APP | Gtk.TargetFlags.OTHER_WIDGET, 0 } // TODO: TEXT_URI
@@ -55,14 +54,8 @@ public class Tasks.Application : Gtk.Application {
 
         var quit_action = new SimpleAction ("quit", null);
         quit_action.activate.connect (() => {
-            if (main_window != null) {
-                /** Gtk.Window.close triggers the Gtk.Window.delete_event
-                which we bind to further down below to set main_window = null.
-                This ensures we always get the same behaviour (set main_window = null),
-                regardless if we use the accelerator or the window close button in
-                the header bar to stop the application.
-                */
-                main_window.close ();
+            if (active_window != null) {
+                active_window.destroy ();
             }
         });
 
@@ -78,15 +71,11 @@ public class Tasks.Application : Gtk.Application {
             return;
         }
 
-        if (get_windows ().length () > 0) {
-            get_windows ().data.present ();
-            return;
-        }
-
-        if (main_window == null) {
+        if (active_window == null) {
             model.start.begin ();
 
-            main_window = new MainWindow (this);
+            var main_window = new MainWindow (this);
+            add_window(main_window);
 
             int window_x, window_y;
             var rect = Gtk.Allocation ();
@@ -116,11 +105,7 @@ public class Tasks.Application : Gtk.Application {
             main_window.show_all ();
         }
 
-        main_window.present ();
-        main_window.delete_event.connect ((event) => {
-            main_window = null;
-            return Gdk.EVENT_PROPAGATE;
-        });
+        active_window.present ();
     }
 
     private static Gee.HashMap<string, Gtk.CssProvider>? providers;


### PR DESCRIPTION
This PR does some refactoring to make lifecycle management of the main_window easier. This allows us to get rid of an additional instance variable and is based upon the findings of https://github.com/elementary/mail/issues/721

This PR also adds the missing changelog entry about the new Notifications in AppData.