### PR TITLE
Add support for Tags/Categories

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,7 @@ executable(
     'src/Widgets/EntryPopover/DateTime.vala',
     'src/Widgets/EntryPopover/Generic.vala',
     'src/Widgets/EntryPopover/Location.vala',
+    'src/Widgets/EntryPopover/Tag.vala',
     'src/Widgets/ScheduledRow.vala',
     'src/Widgets/SourceRow.vala',
     'src/Widgets/ScheduledTaskListGrid.vala',

--- a/src/Widgets/EntryPopover/Tag.vala
+++ b/src/Widgets/EntryPopover/Tag.vala
@@ -1,0 +1,60 @@
+/*
+* Copyright 2021 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+public class Tasks.Widgets.EntryPopover.Tag : Generic<string?> {
+
+    /**
+    We should make use of the available category management functions from EDS here:
+
+    - https://valadoc.org/libedataserver-1.2/E.categories_add.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_dup_icon_file_for.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_dup_list.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_exist.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_is_searchable.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_register_change_listener.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_remove.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_set_icon_file_for.html
+    - https://valadoc.org/libedataserver-1.2/E.categories_unregister_change_listener.html
+    */
+
+    public Tag () {
+        Object (
+            icon_name: "folder-tag-symbolic",
+            placeholder: _("Select Tags")
+        );
+    }
+
+    construct {
+        var grid = new Gtk.Grid () {
+            margin_top= 3
+        };
+        grid.show_all ();
+
+        popover.add (grid);
+
+        popover.show.connect (on_popover_show);
+    }
+
+    private void on_popover_show () {
+        var available_categories = E.categories_dup_list ();
+        available_categories.foreach((category) => {
+            debug ("Available Category: %s", category);
+        });
+    }
+}

--- a/src/Widgets/TaskRow.vala
+++ b/src/Widgets/TaskRow.vala
@@ -38,6 +38,9 @@ public class Tasks.Widgets.TaskRow : Gtk.ListBoxRow {
     private Tasks.Widgets.EntryPopover.Location location_popover;
     private Gtk.Revealer location_popover_revealer;
 
+    private Tasks.Widgets.EntryPopover.Tag tag_popover;
+    private Gtk.Revealer tag_popover_revealer;
+
     private Gtk.EventBox event_box;
     private Gtk.Stack state_stack;
     private Gtk.Image icon;
@@ -198,6 +201,15 @@ public class Tasks.Widgets.TaskRow : Gtk.ListBoxRow {
             }
         });
 
+        tag_popover = new Tasks.Widgets.EntryPopover.Tag ();
+
+        tag_popover_revealer = new Gtk.Revealer () {
+            margin_end = 6,
+            reveal_child = false,
+            transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT
+        };
+        tag_popover_revealer.add (tag_popover);
+
         description_label = new Gtk.Label (null) {
             xalign = 0,
             lines = 1,
@@ -215,6 +227,7 @@ public class Tasks.Widgets.TaskRow : Gtk.ListBoxRow {
         var task_grid = new Gtk.Grid ();
         task_grid.add (due_datetime_popover_revealer);
         task_grid.add (location_popover_revealer);
+        task_grid.add (tag_popover_revealer);
         task_grid.add (description_label_revealer);
 
         task_detail_revealer = new Gtk.Revealer () {
@@ -514,10 +527,12 @@ public class Tasks.Widgets.TaskRow : Gtk.ListBoxRow {
         description_label_revealer.reveal_child = value && description_label.label != null && description_label.label.strip ().length > 0;
         due_datetime_popover_revealer.reveal_child = !value || due_datetime_popover.value != null;
         location_popover_revealer.reveal_child = !value || location_popover.value != null;
+        tag_popover_revealer.reveal_child = !value || tag_popover.value != null;
 
         task_detail_revealer.reveal_child = description_label_revealer.reveal_child ||
             due_datetime_popover_revealer.reveal_child ||
-            location_popover_revealer.reveal_child;
+            location_popover_revealer.reveal_child ||
+            tag_popover_revealer.reveal_child;
     }
 
     private void remove_request () {


### PR DESCRIPTION
This PR is a show case on how we could potentially integrate Tag/Category support in Tasks. It seems rather straight forward by using the categories from EDS. This is related to https://github.com/elementary/tasks/issues/305.

However, it probably makes sense to finish porting to Gtk4 first (https://github.com/elementary/tasks/issues/317), since we are going to introduce quite some new UI elements here for handling Tags/Categories - therefore increasing overall complexity for migration.