### PR TITLE
Auto refresh task lists and collections

### DIFF
--- a/data/tasks.appdata.xml.in
+++ b/data/tasks.appdata.xml.in
@@ -13,6 +13,14 @@
     </p>
   </description>
   <releases>
+    <release version="6.3.0" date="2022-04-28" urgency="medium">
+      <description>
+        <p>Features:</p>
+        <ul>
+          <li>Automatically synchronize a task list whenever it is selected or the network becomes available again</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.2.0" date="2022-01-22" urgency="medium">
       <description>
         <p>Features:</p>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -184,6 +184,15 @@ public class Tasks.MainWindow : Hdy.ApplicationWindow {
                         var source = ((Tasks.Widgets.SourceRow) row).source;
                         var source_uid = source.dup_uid ();
 
+                        /* Synchronizing the list whenever its selected discovers task changes done on remote (likely to happen when multiple devices are used) */
+                        Tasks.Application.model.refresh_task_list.begin (source, null, () => {
+                            try {
+                                Tasks.Application.model.refresh_task_list.end (res);
+                            } catch (Error e) {
+                                warning ("Error syncing task list '%s': %s", source.dup_display_name (), e.message);
+                            }
+                        });
+
                         task_list_grid = (Tasks.Widgets.TaskListGrid) task_list_grid_stack.get_child_by_name (source_uid);
                         if (task_list_grid == null) {
                             task_list_grid = new Tasks.Widgets.TaskListGrid (source);

--- a/src/TaskModel.vala
+++ b/src/TaskModel.vala
@@ -36,6 +36,7 @@ public class Tasks.TaskModel : Object {
     public delegate void TasksRemovedFunc (SList<ECal.ComponentId?> cids);
 
     private Gee.Future<E.SourceRegistry> registry;
+    private NetworkMonitor network_monitor;
     private HashTable<string, ECal.Client> task_list_client;
     private HashTable<ECal.Client, Gee.Collection<ECal.ClientView>> task_list_client_views;
 
@@ -109,13 +110,15 @@ public class Tasks.TaskModel : Object {
     construct {
         task_list_client = new HashTable<string, ECal.Client> (str_hash, str_equal);
         task_list_client_views = new HashTable<ECal.Client, Gee.Collection<ECal.ClientView>> (direct_hash, direct_equal);  // vala-lint=line-length
+        network_monitor = NetworkMonitor.get_default ();
     }
 
     public async void start () {
         var promise = new Gee.Promise<E.SourceRegistry> ();
         registry = promise.future;
         yield init_registry (promise);
-    }
+        network_monitor.network_changed.connect (network_changed);
+    }    
 
     private async void init_registry (Gee.Promise<E.SourceRegistry> promise) {
         try {
@@ -160,6 +163,67 @@ public class Tasks.TaskModel : Object {
             critical (e.message);
             promise.set_exception (e);
         }
+    }
+
+    private uint network_changed_debounce_timeout_id = 0;
+
+    private void network_changed (bool network_available) {
+        if (network_changed_debounce_timeout_id > 0) {
+            Source.remove (network_changed_debounce_timeout_id);
+            network_changed_debounce_timeout_id = 0;
+        }
+
+        network_changed_debounce_timeout_id = Timeout.add_seconds (2, () => {
+            network_changed_debounce_timeout_id = 0;
+
+            debug ("Network is available: '%s'", network_available.to_string ());
+
+            if (network_available && registry.ready) {
+                /* Synchronizing the task list discovers task changes done on remote (more likely to happen) */
+                registry.value.list_sources (E.SOURCE_EXTENSION_TASK_LIST).foreach(task_list => {
+                    refresh_task_list.begin (task_list, null, (obj, res) => {
+                        try {
+                            refresh_task_list.end (res);
+                        } catch (Error e) {
+                            warning ("Error syncing task list '%s': %s", task_list.dup_display_name (), e.message);
+                        }
+                    });
+                });
+
+                /* Synchronizing the collection discovers task list changes done on remote (less likely to happen) */
+                registry.value.list_sources (E.SOURCE_EXTENSION_COLLECTION).foreach((collection_source) => {
+                    refresh_collection.begin  (collection_source, null, (obj, res) => {
+                        try {
+                            refresh_collection.end (res);
+                        } catch (Error e) {
+                            warning ("Error syncing collection '%s': %s", collection_source.dup_display_name (), e.message);
+                        }
+                    });
+                });
+            }
+
+            return Source.REMOVE;
+        });
+    }
+
+    private async bool refresh_collection (E.Source collection_source, Cancellable? cancellable = null) throws Error {
+        if (network_monitor.network_available && registry.ready) {
+            debug ("Scheduling collection refresh '%s'…", collection_source.dup_display_name ());
+            return yield registry.value.refresh_backend (collection_source.dup_uid (), cancellable);
+        }
+        return false;
+    }
+
+    public async bool refresh_task_list (E.Source task_list, Cancellable? cancellable = null) throws Error {
+        if (network_monitor.network_available && task_list_client.contains (task_list.dup_uid ())) {
+            var client = task_list_client.get (task_list.dup_uid ());
+
+            if (client.check_refresh_supported ()) {
+                debug ("Scheduling task list refresh '%s'…", task_list.dup_display_name ());
+                return yield client.refresh (cancellable);
+            }
+        }
+        return false;
     }
 
     public async void add_task_list (E.Source task_list, E.Source collection_or_sibling) throws Error {

--- a/src/TaskModel.vala
+++ b/src/TaskModel.vala
@@ -118,7 +118,7 @@ public class Tasks.TaskModel : Object {
         registry = promise.future;
         yield init_registry (promise);
         network_monitor.network_changed.connect (network_changed);
-    }    
+    }
 
     private async void init_registry (Gee.Promise<E.SourceRegistry> promise) {
         try {
@@ -180,7 +180,7 @@ public class Tasks.TaskModel : Object {
 
             if (network_available && registry.ready) {
                 /* Synchronizing the task list discovers task changes done on remote (more likely to happen) */
-                registry.value.list_sources (E.SOURCE_EXTENSION_TASK_LIST).foreach(task_list => {
+                registry.value.list_sources (E.SOURCE_EXTENSION_TASK_LIST).foreach (task_list => {
                     refresh_task_list.begin (task_list, null, (obj, res) => {
                         try {
                             refresh_task_list.end (res);
@@ -191,8 +191,8 @@ public class Tasks.TaskModel : Object {
                 });
 
                 /* Synchronizing the collection discovers task list changes done on remote (less likely to happen) */
-                registry.value.list_sources (E.SOURCE_EXTENSION_COLLECTION).foreach((collection_source) => {
-                    refresh_collection.begin  (collection_source, null, (obj, res) => {
+                registry.value.list_sources (E.SOURCE_EXTENSION_COLLECTION).foreach ((collection_source) => {
+                    refresh_collection.begin (collection_source, null, (obj, res) => {
                         try {
                             refresh_collection.end (res);
                         } catch (Error e) {


### PR DESCRIPTION
This PR introduces an automatic way of keeping task lists current: Instead of just relaying on a regular sync interval we try to be a bit smarter and automatically synchronize a task list whenever it is selected by the user and a network connection is available - or if the network becomes available again.

This fixes https://github.com/elementary/tasks/issues/306 as it basically obsoletes an extra refresh button.