### PR TITLE
flatpak: Update the dependencies

### DIFF
--- a/io.elementary.tasks.yml
+++ b/io.elementary.tasks.yml
@@ -37,9 +37,9 @@ modules:
       - '-DGOBJECT_INTROSPECTION=true'
       - '-DICAL_BUILD_DOCS=false'
     sources:
-      - type: git
-        url: https://github.com/libical/libical.git
-        tag: v3.0.16
+      - type: archive
+        url: https://github.com/libical/libical/releases/download/v3.0.16/libical-3.0.16.tar.gz
+        sha256: b44705dd71ca4538c86fb16248483ab4b48978524fb1da5097bd76aa2e0f0c33
 
   - name: evolution-data-server
     buildsystem: cmake-ninja
@@ -62,9 +62,9 @@ modules:
       - '-DENABLE_GTK_DOC=OFF'
       - '-DENABLE_EXAMPLES=OFF'
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/evolution-data-server.git
-        tag: '3.46.2'
+      - type: archive
+        url: https://download.gnome.org/sources/evolution-data-server/3.46/evolution-data-server-3.46.4.tar.xz
+        sha256: a59b254145c59facd7c7b5382db78dc5f0ed1f6a6e9b8fe7d5e75959f93c0cc8
       - type: patch
         path: 'eds-gdatasession.patch'
     modules:
@@ -102,6 +102,7 @@ modules:
           - "--disable-gtk-doc"
           - "--enable-egl-backend"
           - "--enable-wayland-backend"
+          - "--enable-deprecated=no"
         cleanup:
           - "/share/gtk-doc"
         sources:
@@ -121,9 +122,9 @@ modules:
   - name: champlain
     buildsystem: meson
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/libchamplain.git
-        branch: 'tintou/libsoup3'
+      - type: archive
+        url: https://download.gnome.org/sources/libchamplain/0.12/libchamplain-0.12.21.tar.xz
+        sha256: a915cd172a0c52944c5579fcb4683f8a878c571bf5e928254b5dafefc727e5a7
 
   - name: geocode-glib
     buildsystem: meson
@@ -132,9 +133,9 @@ modules:
       - '-Denable-gtk-doc=false'
       - '-Dsoup2=false'
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/geocode-glib.git
-        tag: '3.26.4'
+      - type: archive
+        url: https://download.gnome.org/sources/geocode-glib/3.26/geocode-glib-3.26.4.tar.xz
+        sha256: 2d9a6826d158470449a173871221596da0f83ebdcff98b90c7049089056a37aa
 
   - name: tasks
     buildsystem: meson


### PR DESCRIPTION
Also always use archive type to speedup subsequent builds with flatpak-builder.