### PR TITLE
Fix a small color issue

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -145,6 +145,7 @@ public class Tasks.MainWindow : Hdy.ApplicationWindow {
         task_list_grid_stack = new Gtk.Stack ();
 
         var main_grid = new Gtk.Grid ();
+        main_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_BACKGROUND);
         main_grid.attach (main_header, 0, 0);
         main_grid.attach (task_list_grid_stack, 0, 1);
 


### PR DESCRIPTION
Fix a small color issue that was noticeable using dark mode (see red arrow in the screenshot) by adding `Gtk.STYLE_CLASS_BACKGROUND` to `main_grid`.

Before:

![seesdsadf](https://user-images.githubusercontent.com/106322251/230942470-77ab32f9-b105-47f6-80ed-296d4fc90713.png)

After:

![image](https://user-images.githubusercontent.com/106322251/230941549-186b0853-4daa-4144-8766-4421cfaed020.png)
