### PR TITLE
Fixed Duplicated tasks in Scheduled

### DIFF
--- a/src/Widgets/ScheduledTaskListBox.vala
+++ b/src/Widgets/ScheduledTaskListBox.vala
@@ -33,7 +33,7 @@ public class Tasks.Widgets.ScheduledTaskListBox : Gtk.Box {
     }
 
     private void remove_view (E.Source source) {
-        foreach (unowned Gtk.Widget child in get_children ()) {
+        foreach (unowned Gtk.Widget child in task_list.get_children ()) {
             if (child is Tasks.Widgets.TaskRow && ((Tasks.Widgets.TaskRow) child).source == source) {
                 child.destroy ();
             }


### PR DESCRIPTION
Fixes #359

I tried fix it issue https://github.com/elementary/tasks/issues/359

I think found solution if change get_children () to task_list.get_children () it method can remove repeated items