### PR TITLE
Remove old autostart file

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -6,4 +6,6 @@ flatpak remove --system -y io.elementary.tasks//stable || true
 
 #DEBHELPER#
 
+rm /etc/xdg/autostart/io.elementary.tasks-daemon.desktop
+
 exit 0

--- a/debian/postinst
+++ b/debian/postinst
@@ -6,6 +6,6 @@ flatpak remove --system -y io.elementary.tasks//stable || true
 
 #DEBHELPER#
 
-rm /etc/xdg/autostart/io.elementary.tasks-daemon.desktop
+rm /etc/xdg/autostart/io.elementary.tasks-daemon.desktop || true
 
 exit 0


### PR DESCRIPTION
Fixes #369 

Tested locally and it actually removes the file.